### PR TITLE
merge rename-node into master

### DIFF
--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -1,6 +1,9 @@
 # CHANGELOG for 0.x
 This changelog references the relevant changes done in 0.x versions.
 
+## v03.16
+* Fix bug in `AbstractRenameNodeHandler` which attempts to use `node_status` instead of `status` when setting `node_status` field on `NodeRenamed` event.
+
 
 ## v0.3.15
 * When `SearchNodesRequest` in `ElasticaNcrSearch` has `cursor` then always use page 1.

--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -2,7 +2,7 @@
 This changelog references the relevant changes done in 0.x versions.
 
 
-## v03.16
+## v0.3.16
 * Fix bug in `AbstractRenameNodeHandler` which attempts to use `node_status` instead of `status` when setting `node_status` field on `NodeRenamed` event.
 
 

--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -1,6 +1,7 @@
 # CHANGELOG for 0.x
 This changelog references the relevant changes done in 0.x versions.
 
+
 ## v03.16
 * Fix bug in `AbstractRenameNodeHandler` which attempts to use `node_status` instead of `status` when setting `node_status` field on `NodeRenamed` event.
 

--- a/src/AbstractRenameNodeHandler.php
+++ b/src/AbstractRenameNodeHandler.php
@@ -43,7 +43,7 @@ abstract class AbstractRenameNodeHandler extends AbstractNodeCommandHandler
             ->set('node_ref', $nodeRef)
             ->set('new_slug', $command->get('new_slug'))
             ->set('old_slug', $node->get('slug'))
-            ->set('node_status', $node->get('node_status'));
+            ->set('node_status', $node->get('node'));
 
         $this->bindFromNode($event, $node, $pbjx);
         $this->putEvents($command, $pbjx, $this->createStreamId($nodeRef, $command, $event), [$event]);

--- a/src/AbstractRenameNodeHandler.php
+++ b/src/AbstractRenameNodeHandler.php
@@ -43,7 +43,7 @@ abstract class AbstractRenameNodeHandler extends AbstractNodeCommandHandler
             ->set('node_ref', $nodeRef)
             ->set('new_slug', $command->get('new_slug'))
             ->set('old_slug', $node->get('slug'))
-            ->set('node_status', $node->get('node'));
+            ->set('node_status', $node->get('status'));
 
         $this->bindFromNode($event, $node, $pbjx);
         $this->putEvents($command, $pbjx, $this->createStreamId($nodeRef, $command, $event), [$event]);


### PR DESCRIPTION
* Fix bug in `AbstractRenameNodeHandler` which attempts to use `node_status` instead of `status` when setting `node_status` field on `NodeRenamed` event.
