### PR TITLE
v2.1.1

### DIFF
--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -5,6 +5,7 @@ This changelog references the relevant changes done in 2.x versions.
 ## v2.1.1
 * Add implementations for `gdbots:ncr:command:update-node-labels` and `gdbots:ncr:command:update-node-tags`.
 * Fix bug in `GetNodeRequestHandler` where `$nodeRef` wasn't set when doing a slug lookup.
+* Remove use of mixin/message constants for fields and schema refs as it's too noisy and isn't enough of a help to warrant it.
 
 
 ## v2.1.0

--- a/CHANGELOG-2.x.md
+++ b/CHANGELOG-2.x.md
@@ -2,6 +2,11 @@
 This changelog references the relevant changes done in 2.x versions.
 
 
+## v2.1.1
+* Add implementations for `gdbots:ncr:command:update-node-labels` and `gdbots:ncr:command:update-node-tags`.
+* Fix bug in `GetNodeRequestHandler` where `$nodeRef` wasn't set when doing a slug lookup.
+
+
 ## v2.1.0
 * Uses `"gdbots/pbj": "^3.1"` with context arg for `Pbjx::sendAt` and `Pbjx::cancelJobs`.
 

--- a/src/AbstractSearchNodesRequestHandler.php
+++ b/src/AbstractSearchNodesRequestHandler.php
@@ -13,7 +13,6 @@ use Gdbots\QueryParser\Node\Field;
 use Gdbots\QueryParser\Node\Word;
 use Gdbots\QueryParser\ParsedQuery;
 use Gdbots\Schemas\Ncr\Enum\NodeStatus;
-use Gdbots\Schemas\Ncr\Mixin\SearchNodesRequest\SearchNodesRequestV1Mixin;
 
 abstract class AbstractSearchNodesRequestHandler implements RequestHandler
 {
@@ -28,7 +27,7 @@ abstract class AbstractSearchNodesRequestHandler implements RequestHandler
     {
         $response = $this->createSearchNodesResponse($request, $pbjx);
         $parsedQuery = ParsedQuery::fromArray(json_decode(
-            $request->get(SearchNodesRequestV1Mixin::PARSED_QUERY_JSON_FIELD, '{}'),
+            $request->get('parsed_query_json', '{}'),
             true
         ));
 
@@ -36,19 +35,12 @@ abstract class AbstractSearchNodesRequestHandler implements RequestHandler
 
         // if status is not specified in some way, default to not
         // showing any deleted nodes.
-        if (!$request->has(SearchNodesRequestV1Mixin::STATUS_FIELD)
-            && !$request->has(SearchNodesRequestV1Mixin::STATUSES_FIELD)
-            && !$request->isInSet(
-                SearchNodesRequestV1Mixin::FIELDS_USED_FIELD,
-                SearchNodesRequestV1Mixin::STATUS_FIELD
-            )
+        if (!$request->has('status')
+            && !$request->has('statuses')
+            && !$request->isInSet('fields_used', 'status')
         ) {
             $parsedQuery->addNode(
-                new Field(
-                    SearchNodesRequestV1Mixin::STATUS_FIELD,
-                    new Word(NodeStatus::DELETED, $prohibited),
-                    $prohibited
-                )
+                new Field('status', new Word(NodeStatus::DELETED, $prohibited), $prohibited)
             );
         }
 

--- a/src/CreateNodeHandler.php
+++ b/src/CreateNodeHandler.php
@@ -7,23 +7,21 @@ use Gdbots\Pbj\Message;
 use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Command\CreateNodeV1;
-use Gdbots\Schemas\Ncr\Mixin\CreateNode\CreateNodeV1Mixin;
 
 class CreateNodeHandler implements CommandHandler
 {
     public static function handlesCuries(): array
     {
         // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin(CreateNodeV1Mixin::SCHEMA_CURIE_MAJOR, false);
-        $curies[] = CreateNodeV1::SCHEMA_CURIE;
+        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:create-node:v1', false);
+        $curies[] = 'gdbots:ncr:command:create-node';
         return $curies;
     }
 
     public function handleCommand(Message $command, Pbjx $pbjx): void
     {
         /** @var Message $node */
-        $node = $command->get(CreateNodeV1::NODE_FIELD);
+        $node = $command->get('node');
         $context = ['causator' => $command];
 
         $aggregate = AggregateResolver::resolve($node::schema()->getQName())::fromNode($node, $pbjx);

--- a/src/DeleteNodeHandler.php
+++ b/src/DeleteNodeHandler.php
@@ -8,8 +8,6 @@ use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Command\DeleteNodeV1;
-use Gdbots\Schemas\Ncr\Mixin\DeleteNode\DeleteNodeV1Mixin;
 
 class DeleteNodeHandler implements CommandHandler
 {
@@ -18,8 +16,8 @@ class DeleteNodeHandler implements CommandHandler
     public static function handlesCuries(): array
     {
         // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin(DeleteNodeV1Mixin::SCHEMA_CURIE_MAJOR, false);
-        $curies[] = DeleteNodeV1::SCHEMA_CURIE;
+        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:delete-node:v1', false);
+        $curies[] = 'gdbots:ncr:command:delete-node';
         return $curies;
     }
 
@@ -31,7 +29,7 @@ class DeleteNodeHandler implements CommandHandler
     public function handleCommand(Message $command, Pbjx $pbjx): void
     {
         /** @var NodeRef $nodeRef */
-        $nodeRef = $command->get(DeleteNodeV1::NODE_REF_FIELD);
+        $nodeRef = $command->get('node_ref');
         $context = ['causator' => $command];
 
         $node = $this->ncr->getNode($nodeRef, true, $context);

--- a/src/ExpireNodeHandler.php
+++ b/src/ExpireNodeHandler.php
@@ -8,8 +8,6 @@ use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Command\ExpireNodeV1;
-use Gdbots\Schemas\Ncr\Mixin\ExpireNode\ExpireNodeV1Mixin;
 
 class ExpireNodeHandler implements CommandHandler
 {
@@ -18,8 +16,8 @@ class ExpireNodeHandler implements CommandHandler
     public static function handlesCuries(): array
     {
         // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin(ExpireNodeV1Mixin::SCHEMA_CURIE_MAJOR, false);
-        $curies[] = ExpireNodeV1::SCHEMA_CURIE;
+        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:expire-node:v1', false);
+        $curies[] = 'gdbots:ncr:command:expire-node';
         return $curies;
     }
 
@@ -31,7 +29,7 @@ class ExpireNodeHandler implements CommandHandler
     public function handleCommand(Message $command, Pbjx $pbjx): void
     {
         /** @var NodeRef $nodeRef */
-        $nodeRef = $command->get(ExpireNodeV1::NODE_REF_FIELD);
+        $nodeRef = $command->get('node_ref');
         $context = ['causator' => $command];
 
         $node = $this->ncr->getNode($nodeRef, true, $context);

--- a/src/GetNodeHistoryRequestHandler.php
+++ b/src/GetNodeHistoryRequestHandler.php
@@ -7,7 +7,6 @@ use Gdbots\Pbj\Message;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\Pbjx;
 use Gdbots\Pbjx\RequestHandler;
-use Gdbots\Schemas\Ncr\Request\GetNodeHistoryRequestV1;
 use Gdbots\Schemas\Ncr\Request\GetNodeHistoryResponseV1;
 use Gdbots\Schemas\Pbjx\StreamId;
 
@@ -16,29 +15,29 @@ class GetNodeHistoryRequestHandler implements RequestHandler
     public static function handlesCuries(): array
     {
         return [
-            GetNodeHistoryRequestV1::SCHEMA_CURIE,
+            'gdbots:ncr:request:get-node-history-request',
         ];
     }
 
     public function handleRequest(Message $request, Pbjx $pbjx): Message
     {
         /** @var NodeRef $nodeRef */
-        $nodeRef = $request->get(GetNodeHistoryRequestV1::NODE_REF_FIELD);
+        $nodeRef = $request->get('node_ref');
         $response = GetNodeHistoryResponseV1::create();
         $context = ['causator' => $request];
 
         $streamId = StreamId::fromNodeRef($nodeRef);
         $slice = $pbjx->getEventStore()->getStreamSlice(
             $streamId,
-            $request->get(GetNodeHistoryRequestV1::SINCE_FIELD),
-            $request->get(GetNodeHistoryRequestV1::COUNT_FIELD),
-            $request->get(GetNodeHistoryRequestV1::FORWARD_FIELD),
+            $request->get('since'),
+            $request->get('count'),
+            $request->get('forward'),
             true,
             $context
         );
 
-        return $response->set($response::HAS_MORE_FIELD, $slice->hasMore())
-            ->set($response::LAST_OCCURRED_AT_FIELD, $slice->getLastOccurredAt())
-            ->addToList($response::EVENTS_FIELD, $slice->toArray()['events']);
+        return $response->set('has_more', $slice->hasMore())
+            ->set('last_occurred_at', $slice->getLastOccurredAt())
+            ->addToList('events', $slice->toArray()['events']);
     }
 }

--- a/src/LockNodeHandler.php
+++ b/src/LockNodeHandler.php
@@ -8,8 +8,6 @@ use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Command\LockNodeV1;
-use Gdbots\Schemas\Ncr\Mixin\LockNode\LockNodeV1Mixin;
 
 class LockNodeHandler implements CommandHandler
 {
@@ -18,8 +16,8 @@ class LockNodeHandler implements CommandHandler
     public static function handlesCuries(): array
     {
         // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin(LockNodeV1Mixin::SCHEMA_CURIE_MAJOR, false);
-        $curies[] = LockNodeV1::SCHEMA_CURIE;
+        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:lock-node:v1', false);
+        $curies[] = 'gdbots:ncr:command:lock-node';
         return $curies;
     }
 
@@ -31,7 +29,7 @@ class LockNodeHandler implements CommandHandler
     public function handleCommand(Message $command, Pbjx $pbjx): void
     {
         /** @var NodeRef $nodeRef */
-        $nodeRef = $command->get(LockNodeV1::NODE_REF_FIELD);
+        $nodeRef = $command->get('node_ref');
         $context = ['causator' => $command];
 
         $node = $this->ncr->getNode($nodeRef, true, $context);

--- a/src/MarkNodeAsDraftHandler.php
+++ b/src/MarkNodeAsDraftHandler.php
@@ -8,8 +8,6 @@ use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Command\MarkNodeAsDraftV1;
-use Gdbots\Schemas\Ncr\Mixin\MarkNodeAsDraft\MarkNodeAsDraftV1Mixin;
 
 class MarkNodeAsDraftHandler implements CommandHandler
 {
@@ -18,8 +16,8 @@ class MarkNodeAsDraftHandler implements CommandHandler
     public static function handlesCuries(): array
     {
         // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin(MarkNodeAsDraftV1Mixin::SCHEMA_CURIE_MAJOR, false);
-        $curies[] = MarkNodeAsDraftV1::SCHEMA_CURIE;
+        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:mark-node-as-draft:v1', false);
+        $curies[] = 'gdbots:ncr:command:mark-node-as-draft';
         return $curies;
     }
 
@@ -31,7 +29,7 @@ class MarkNodeAsDraftHandler implements CommandHandler
     public function handleCommand(Message $command, Pbjx $pbjx): void
     {
         /** @var NodeRef $nodeRef */
-        $nodeRef = $command->get(MarkNodeAsDraftV1::NODE_REF_FIELD);
+        $nodeRef = $command->get('node_ref');
         $context = ['causator' => $command];
 
         $node = $this->ncr->getNode($nodeRef, true, $context);

--- a/src/MarkNodeAsPendingHandler.php
+++ b/src/MarkNodeAsPendingHandler.php
@@ -8,8 +8,6 @@ use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Command\MarkNodeAsPendingV1;
-use Gdbots\Schemas\Ncr\Mixin\MarkNodeAsPending\MarkNodeAsPendingV1Mixin;
 
 class MarkNodeAsPendingHandler implements CommandHandler
 {
@@ -18,8 +16,8 @@ class MarkNodeAsPendingHandler implements CommandHandler
     public static function handlesCuries(): array
     {
         // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin(MarkNodeAsPendingV1Mixin::SCHEMA_CURIE_MAJOR, false);
-        $curies[] = MarkNodeAsPendingV1::SCHEMA_CURIE;
+        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:mark-node-as-pending:v1', false);
+        $curies[] = 'gdbots:ncr:command:mark-node-as-pending';
         return $curies;
     }
 
@@ -31,7 +29,7 @@ class MarkNodeAsPendingHandler implements CommandHandler
     public function handleCommand(Message $command, Pbjx $pbjx): void
     {
         /** @var NodeRef $nodeRef */
-        $nodeRef = $command->get(MarkNodeAsPendingV1::NODE_REF_FIELD);
+        $nodeRef = $command->get('node_ref');
         $context = ['causator' => $command];
 
         $node = $this->ncr->getNode($nodeRef, true, $context);

--- a/src/NcrLazyLoader.php
+++ b/src/NcrLazyLoader.php
@@ -38,7 +38,7 @@ final class NcrLazyLoader
             return false;
         }
 
-        return $this->getNodeBatchRequest->isInSet(GetNodeBatchRequestV1::NODE_REFS_FIELD, $nodeRef);
+        return $this->getNodeBatchRequest->isInSet('node_refs', $nodeRef);
     }
 
     /**
@@ -52,7 +52,7 @@ final class NcrLazyLoader
             return [];
         }
 
-        return $this->getNodeBatchRequest->get(GetNodeBatchRequestV1::NODE_REFS_FIELD, []);
+        return $this->getNodeBatchRequest->get('node_refs', []);
     }
 
     /**
@@ -117,7 +117,7 @@ final class NcrLazyLoader
             $this->getNodeBatchRequest = GetNodeBatchRequestV1::create();
         }
 
-        $this->getNodeBatchRequest->addToSet(GetNodeBatchRequestV1::NODE_REFS_FIELD, $nodeRefs);
+        $this->getNodeBatchRequest->addToSet('node_refs', $nodeRefs);
     }
 
     /**
@@ -131,7 +131,7 @@ final class NcrLazyLoader
             return;
         }
 
-        $this->getNodeBatchRequest->removeFromSet(GetNodeBatchRequestV1::NODE_REFS_FIELD, $nodeRefs);
+        $this->getNodeBatchRequest->removeFromSet('node_refs', $nodeRefs);
     }
 
     /**
@@ -152,14 +152,14 @@ final class NcrLazyLoader
             return;
         }
 
-        if (!$this->getNodeBatchRequest->has(GetNodeBatchRequestV1::NODE_REFS_FIELD)) {
+        if (!$this->getNodeBatchRequest->has('node_refs')) {
             return;
         }
 
         try {
             $request = $this->getNodeBatchRequest;
             $this->getNodeBatchRequest = null;
-            $request->set($request::CTX_CAUSATOR_REF_FIELD, $request->generateMessageRef());
+            $request->set('ctx_causator_ref', $request->generateMessageRef());
             $this->pbjx->request($request);
         } catch (\Throwable $e) {
             $this->logger->error(

--- a/src/NcrPreloader.php
+++ b/src/NcrPreloader.php
@@ -8,7 +8,6 @@ use Gdbots\Pbj\Util\ArrayUtil;
 use Gdbots\Pbj\WellKnown\MessageRef;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Schemas\Ncr\Enum\NodeStatus;
-use Gdbots\Schemas\Ncr\Mixin\Node\NodeV1Mixin;
 
 /**
  * NcrPreloader provides a way to inform the current request
@@ -76,7 +75,7 @@ final class NcrPreloader
     public function getPublishedNodes(string $namespace = self::DEFAULT_NAMESPACE): array
     {
         return $this->getNodes(function (Message $node) {
-            return NodeStatus::PUBLISHED === $node->fget(NodeV1Mixin::STATUS_FIELD);
+            return NodeStatus::PUBLISHED === $node->fget('status');
         }, $namespace);
     }
 

--- a/src/NcrProjector.php
+++ b/src/NcrProjector.php
@@ -10,46 +10,22 @@ use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\DependencyInjection\PbjxProjector;
 use Gdbots\Pbjx\EventSubscriber;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Event\NodeCreatedV1;
-use Gdbots\Schemas\Ncr\Event\NodeDeletedV1;
-use Gdbots\Schemas\Ncr\Event\NodeExpiredV1;
-use Gdbots\Schemas\Ncr\Event\NodeLockedV1;
-use Gdbots\Schemas\Ncr\Event\NodeMarkedAsDraftV1;
-use Gdbots\Schemas\Ncr\Event\NodeMarkedAsPendingV1;
-use Gdbots\Schemas\Ncr\Event\NodePublishedV1;
-use Gdbots\Schemas\Ncr\Event\NodeRenamedV1;
-use Gdbots\Schemas\Ncr\Event\NodeScheduledV1;
-use Gdbots\Schemas\Ncr\Event\NodeUnlockedV1;
-use Gdbots\Schemas\Ncr\Event\NodeUnpublishedV1;
-use Gdbots\Schemas\Ncr\Event\NodeUpdatedV1;
-use Gdbots\Schemas\Ncr\Mixin\NodeCreated\NodeCreatedV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodeDeleted\NodeDeletedV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodeExpired\NodeExpiredV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodeLocked\NodeLockedV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodeMarkedAsDraft\NodeMarkedAsDraftV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodeMarkedAsPending\NodeMarkedAsPendingV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodePublished\NodePublishedV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodeRenamed\NodeRenamedV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodeScheduled\NodeScheduledV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodeUnlocked\NodeUnlockedV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodeUnpublished\NodeUnpublishedV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\NodeUpdated\NodeUpdatedV1Mixin;
 
 class NcrProjector implements EventSubscriber, PbjxProjector
 {
     protected const DEPRECATED_MIXINS_TO_SUFFIX = [
-        NodeCreatedV1Mixin::SCHEMA_CURIE         => 'created',
-        NodeDeletedV1Mixin::SCHEMA_CURIE         => 'deleted',
-        NodeExpiredV1Mixin::SCHEMA_CURIE         => 'expired',
-        NodeLockedV1Mixin::SCHEMA_CURIE          => 'locked',
-        NodeMarkedAsDraftV1Mixin::SCHEMA_CURIE   => 'marked-as-draft',
-        NodeMarkedAsPendingV1Mixin::SCHEMA_CURIE => 'marked-as-pending',
-        NodePublishedV1Mixin::SCHEMA_CURIE       => 'published',
-        NodeRenamedV1Mixin::SCHEMA_CURIE         => 'renamed',
-        NodeScheduledV1Mixin::SCHEMA_CURIE       => 'scheduled',
-        NodeUnlockedV1Mixin::SCHEMA_CURIE        => 'unlocked',
-        NodeUnpublishedV1Mixin::SCHEMA_CURIE     => 'unpublished',
-        NodeUpdatedV1Mixin::SCHEMA_CURIE         => 'updated',
+        'gdbots:ncr:mixin:node-created'           => 'created',
+        'gdbots:ncr:mixin:node-deleted'           => 'deleted',
+        'gdbots:ncr:mixin:node-expired'           => 'expired',
+        'gdbots:ncr:mixin:node-locked'            => 'locked',
+        'gdbots:ncr:mixin:node-marked-as-draft'   => 'marked-as-draft',
+        'gdbots:ncr:mixin:node-marked-as-pending' => 'marked-as-pending',
+        'gdbots:ncr:mixin:node-published'         => 'published',
+        'gdbots:ncr:mixin:node-renamed'           => 'renamed',
+        'gdbots:ncr:mixin:node-scheduled'         => 'scheduled',
+        'gdbots:ncr:mixin:node-unlocked'          => 'unlocked',
+        'gdbots:ncr:mixin:node-unpublished'       => 'unpublished',
+        'gdbots:ncr:mixin:node-updated'           => 'updated',
     ];
 
     protected Ncr $ncr;
@@ -59,32 +35,34 @@ class NcrProjector implements EventSubscriber, PbjxProjector
     public static function getSubscribedEvents()
     {
         return [
-            NodeCreatedV1::SCHEMA_CURIE              => 'onNodeCreated',
-            NodeDeletedV1::SCHEMA_CURIE              => 'onNodeDeleted',
-            NodeExpiredV1::SCHEMA_CURIE              => 'onNodeEvent',
-            NodeLockedV1::SCHEMA_CURIE               => 'onNodeEvent',
-            NodeMarkedAsDraftV1::SCHEMA_CURIE        => 'onNodeEvent',
-            NodeMarkedAsPendingV1::SCHEMA_CURIE      => 'onNodeEvent',
-            NodePublishedV1::SCHEMA_CURIE            => 'onNodeEvent',
-            NodeRenamedV1::SCHEMA_CURIE              => 'onNodeEvent',
-            NodeScheduledV1::SCHEMA_CURIE            => 'onNodeEvent',
-            NodeUnlockedV1::SCHEMA_CURIE             => 'onNodeEvent',
-            NodeUnpublishedV1::SCHEMA_CURIE          => 'onNodeEvent',
-            NodeUpdatedV1::SCHEMA_CURIE              => 'onNodeUpdated',
+            'gdbots:ncr:event:node-created'           => 'onNodeCreated',
+            'gdbots:ncr:event:node-deleted'           => 'onNodeDeleted',
+            'gdbots:ncr:event:node-expired'           => 'onNodeEvent',
+            'gdbots:ncr:event:node-labels-updated'    => 'onNodeEvent',
+            'gdbots:ncr:event:node-locked'            => 'onNodeEvent',
+            'gdbots:ncr:event:node-marked-as-draft'   => 'onNodeEvent',
+            'gdbots:ncr:event:node-marked-as-pending' => 'onNodeEvent',
+            'gdbots:ncr:event:node-published'         => 'onNodeEvent',
+            'gdbots:ncr:event:node-renamed'           => 'onNodeEvent',
+            'gdbots:ncr:event:node-scheduled'         => 'onNodeEvent',
+            'gdbots:ncr:event:node-tags-updated'      => 'onNodeEvent',
+            'gdbots:ncr:event:node-unlocked'          => 'onNodeEvent',
+            'gdbots:ncr:event:node-unpublished'       => 'onNodeEvent',
+            'gdbots:ncr:event:node-updated'           => 'onNodeUpdated',
 
             // deprecated mixins, will be removed in 3.x
-            NodeCreatedV1Mixin::SCHEMA_CURIE         => 'onNodeCreated',
-            NodeDeletedV1Mixin::SCHEMA_CURIE         => 'onNodeDeleted',
-            NodeExpiredV1Mixin::SCHEMA_CURIE         => 'onNodeEvent',
-            NodeLockedV1Mixin::SCHEMA_CURIE          => 'onNodeEvent',
-            NodeMarkedAsDraftV1Mixin::SCHEMA_CURIE   => 'onNodeEvent',
-            NodeMarkedAsPendingV1Mixin::SCHEMA_CURIE => 'onNodeEvent',
-            NodePublishedV1Mixin::SCHEMA_CURIE       => 'onNodeEvent',
-            NodeRenamedV1Mixin::SCHEMA_CURIE         => 'onNodeEvent',
-            NodeScheduledV1Mixin::SCHEMA_CURIE       => 'onNodeEvent',
-            NodeUnlockedV1Mixin::SCHEMA_CURIE        => 'onNodeEvent',
-            NodeUnpublishedV1Mixin::SCHEMA_CURIE     => 'onNodeEvent',
-            NodeUpdatedV1Mixin::SCHEMA_CURIE         => 'onNodeUpdated',
+            'gdbots:ncr:mixin:node-created'           => 'onNodeCreated',
+            'gdbots:ncr:mixin:node-deleted'           => 'onNodeDeleted',
+            'gdbots:ncr:mixin:node-expired'           => 'onNodeEvent',
+            'gdbots:ncr:mixin:node-locked'            => 'onNodeEvent',
+            'gdbots:ncr:mixin:node-marked-as-draft'   => 'onNodeEvent',
+            'gdbots:ncr:mixin:node-marked-as-pending' => 'onNodeEvent',
+            'gdbots:ncr:mixin:node-published'         => 'onNodeEvent',
+            'gdbots:ncr:mixin:node-renamed'           => 'onNodeEvent',
+            'gdbots:ncr:mixin:node-scheduled'         => 'onNodeEvent',
+            'gdbots:ncr:mixin:node-unlocked'          => 'onNodeEvent',
+            'gdbots:ncr:mixin:node-unpublished'       => 'onNodeEvent',
+            'gdbots:ncr:mixin:node-updated'           => 'onNodeUpdated',
         ];
     }
 
@@ -101,7 +79,7 @@ class NcrProjector implements EventSubscriber, PbjxProjector
             return;
         }
 
-        $this->projectNodeRef($event->get($event::NODE_REF_FIELD), $event, $pbjx);
+        $this->projectNodeRef($event->get('node_ref'), $event, $pbjx);
     }
 
     public function onNodeCreated(Message $event, Pbjx $pbjx): void
@@ -110,7 +88,7 @@ class NcrProjector implements EventSubscriber, PbjxProjector
             return;
         }
 
-        $this->projectNode($event->get(NodeCreatedV1::NODE_FIELD), $event, $pbjx);
+        $this->projectNode($event->get('node'), $event, $pbjx);
     }
 
     public function onNodeDeleted(Message $event, Pbjx $pbjx): void
@@ -120,7 +98,7 @@ class NcrProjector implements EventSubscriber, PbjxProjector
         }
 
         /** @var NodeRef $nodeRef */
-        $nodeRef = $event->get(NodeDeletedV1::NODE_REF_FIELD);
+        $nodeRef = $event->get('node_ref');
         $context = ['causator' => $event];
 
         try {
@@ -149,7 +127,7 @@ class NcrProjector implements EventSubscriber, PbjxProjector
             return;
         }
 
-        $this->projectNode($event->get(NodeUpdatedV1::NEW_NODE_FIELD), $event, $pbjx);
+        $this->projectNode($event->get('new_node'), $event, $pbjx);
     }
 
     protected function projectNodeRef(NodeRef $nodeRef, Message $event, Pbjx $pbjx): void

--- a/src/NcrRequestInterceptor.php
+++ b/src/NcrRequestInterceptor.php
@@ -3,24 +3,20 @@ declare(strict_types=1);
 
 namespace Gdbots\Ncr;
 
+use Gdbots\Pbj\Message;
 use Gdbots\Pbj\SchemaQName;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\Event\GetResponseEvent;
 use Gdbots\Pbjx\Event\PbjxEvent;
 use Gdbots\Pbjx\Event\ResponseCreatedEvent;
 use Gdbots\Pbjx\EventSubscriber;
-use Gdbots\Schemas\Ncr\Mixin\GetNodeBatchRequest\GetNodeBatchRequestV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\GetNodeBatchResponse\GetNodeBatchResponseV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\GetNodeRequest\GetNodeRequestV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\GetNodeResponse\GetNodeResponseV1Mixin;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
-final class NcrRequestInterceptor implements EventSubscriber
+class NcrRequestInterceptor implements EventSubscriber
 {
-    private const SLUG_TTL = 300;
-    private CacheItemPoolInterface $cache;
-    private NcrCache $ncrCache;
+    protected CacheItemPoolInterface $cache;
+    protected NcrCache $ncrCache;
 
     /**
      * If a request for nodes contains items already available in NcrCache
@@ -29,7 +25,7 @@ final class NcrRequestInterceptor implements EventSubscriber
      *
      * @var array
      */
-    private array $pickup = [];
+    protected array $pickup = [];
 
     /**
      * When get node requests occur with slugs we will attempt
@@ -38,15 +34,15 @@ final class NcrRequestInterceptor implements EventSubscriber
      *
      * @var CacheItemInterface[]
      */
-    private array $cacheItems = [];
+    protected array $cacheItems = [];
 
     public static function getSubscribedEvents()
     {
         return [
-            GetNodeRequestV1Mixin::SCHEMA_CURIE . '.enrich'             => 'enrichGetNodeRequest',
-            GetNodeBatchRequestV1Mixin::SCHEMA_CURIE . '.before_handle' => 'onGetNodeBatchRequestBeforeHandle',
-            GetNodeResponseV1Mixin::SCHEMA_CURIE . '.created'           => 'onGetNodeResponseCreated',
-            GetNodeBatchResponseV1Mixin::SCHEMA_CURIE . '.created'      => 'onGetNodeBatchResponseCreated',
+            'gdbots:ncr:mixin:get-node-request.enrich'              => 'enrichGetNodeRequest',
+            'gdbots:ncr:mixin:get-node-batch-request.before_handle' => 'onGetNodeBatchRequestBeforeHandle',
+            'gdbots:ncr:mixin:get-node-response.created'            => 'onGetNodeResponseCreated',
+            'gdbots:ncr:mixin:get-node-batch-response.created'      => 'onGetNodeBatchResponseCreated',
         ];
     }
 
@@ -65,16 +61,16 @@ final class NcrRequestInterceptor implements EventSubscriber
     public function enrichGetNodeRequest(PbjxEvent $pbjxEvent): void
     {
         $request = $pbjxEvent->getMessage();
-        if ($request->has(GetNodeRequestV1Mixin::NODE_REF_FIELD)
-            || $request->get(GetNodeRequestV1Mixin::CONSISTENT_READ_FIELD)
-            || !$request->has(GetNodeRequestV1Mixin::QNAME_FIELD)
-            || !$request->has(GetNodeRequestV1Mixin::SLUG_FIELD)
+        if ($request->has('node_ref')
+            || $request->get('consistent_read')
+            || !$request->has('qname')
+            || !$request->has('slug')
         ) {
             return;
         }
 
-        $qname = SchemaQName::fromString($request->get(GetNodeRequestV1Mixin::QNAME_FIELD));
-        $cacheKey = $this->getSlugCacheKey($qname, $request->get(GetNodeRequestV1Mixin::SLUG_FIELD));
+        $qname = SchemaQName::fromString($request->get('qname'));
+        $cacheKey = $this->getSlugCacheKey($qname, $request->get('slug'));
 
         $cacheItem = $this->cache->getItem($cacheKey);
         if (!$cacheItem->isHit()) {
@@ -85,7 +81,7 @@ final class NcrRequestInterceptor implements EventSubscriber
         try {
             $nodeRef = NodeRef::fromString($cacheItem->get());
             if ($nodeRef->getQName() === $qname) {
-                $request->set(GetNodeRequestV1Mixin::NODE_REF_FIELD, $nodeRef);
+                $request->set('node_ref', $nodeRef);
             }
         } catch (\Throwable $e) {
         }
@@ -94,16 +90,14 @@ final class NcrRequestInterceptor implements EventSubscriber
     public function onGetNodeBatchRequestBeforeHandle(GetResponseEvent $pbjxEvent): void
     {
         $request = $pbjxEvent->getRequest();
-        if ($request->get(GetNodeBatchRequestV1Mixin::CONSISTENT_READ_FIELD)
-            || !$request->has(GetNodeBatchRequestV1Mixin::NODE_REFS_FIELD)
-        ) {
+        if ($request->get('consistent_read') || !$request->has('node_refs')) {
             return;
         }
 
         $ncrCachedNodeRefs = [];
 
         /** @var NodeRef $nodeRef */
-        foreach ($request->get(GetNodeBatchRequestV1Mixin::NODE_REFS_FIELD) as $nodeRef) {
+        foreach ($request->get('node_refs') as $nodeRef) {
             if ($this->ncrCache->hasNode($nodeRef)) {
                 $ncrCachedNodeRefs[] = $nodeRef;
             }
@@ -113,42 +107,40 @@ final class NcrRequestInterceptor implements EventSubscriber
             return;
         }
 
-        $request->removeFromSet(GetNodeBatchRequestV1Mixin::NODE_REFS_FIELD, $ncrCachedNodeRefs);
-        $this->pickup[(string)$request->get($request::REQUEST_ID_FIELD)] = $ncrCachedNodeRefs;
+        $request->removeFromSet('node_refs', $ncrCachedNodeRefs);
+        $this->pickup[(string)$request->get('request_id')] = $ncrCachedNodeRefs;
     }
 
     public function onGetNodeResponseCreated(ResponseCreatedEvent $pbjxEvent): void
     {
         $response = $pbjxEvent->getResponse();
-        if (!$response->has(GetNodeResponseV1Mixin::NODE_FIELD)) {
+        if (!$response->has('node')) {
             return;
         }
 
-        $node = $response->get(GetNodeResponseV1Mixin::NODE_FIELD);
+        $node = $response->get('node');
         $this->ncrCache->addNode($node);
 
         $request = $pbjxEvent->getRequest();
-        if (!$request->has(GetNodeRequestV1Mixin::QNAME_FIELD)
-            || !$request->has(GetNodeRequestV1Mixin::SLUG_FIELD)
-        ) {
+        if (!$request->has('qname') || !$request->has('slug')) {
             // was not a slug lookup
             return;
         }
 
-        if ($node->get(GetNodeRequestV1Mixin::SLUG_FIELD) !== $request->get(GetNodeRequestV1Mixin::SLUG_FIELD)) {
+        if ($node->get('slug') !== $request->get('slug')) {
             // for some reason, the node we got ain't the one we want
             return;
         }
 
         $nodeRef = NodeRef::fromNode($node);
-        $cacheKey = $this->getSlugCacheKey($nodeRef->getQName(), $request->get(GetNodeRequestV1Mixin::SLUG_FIELD));
+        $cacheKey = $this->getSlugCacheKey($nodeRef->getQName(), $request->get('slug'));
         if (!isset($this->cacheItems[$cacheKey])) {
             // lookup never happend
             return;
         }
 
         $cacheItem = $this->cacheItems[$cacheKey];
-        $cacheItem->set($nodeRef->toString())->expiresAfter(self::SLUG_TTL);
+        $cacheItem->set($nodeRef->toString())->expiresAfter($this->getSlugCacheTtl($nodeRef->getQName(), $request));
         unset($this->cacheItems[$cacheKey]);
         $this->cache->saveDeferred($cacheItem);
     }
@@ -156,11 +148,11 @@ final class NcrRequestInterceptor implements EventSubscriber
     public function onGetNodeBatchResponseCreated(ResponseCreatedEvent $pbjxEvent): void
     {
         $response = $pbjxEvent->getResponse();
-        if ($response->has(GetNodeBatchResponseV1Mixin::NODES_FIELD)) {
-            $this->ncrCache->addNodes($response->get(GetNodeBatchResponseV1Mixin::NODES_FIELD));
+        if ($response->has('nodes')) {
+            $this->ncrCache->addNodes($response->get('nodes'));
         }
 
-        $requestId = $response->get($response::CTX_REQUEST_REF_FIELD)->getId();
+        $requestId = $response->get('ctx_request_ref')->getId();
         if (!isset($this->pickup[$requestId])) {
             return;
         }
@@ -168,20 +160,16 @@ final class NcrRequestInterceptor implements EventSubscriber
         /** @var NodeRef $nodeRef */
         foreach ($this->pickup[$requestId] as $nodeRef) {
             try {
-                $response->addToMap(
-                    GetNodeBatchResponseV1Mixin::NODES_FIELD,
-                    $nodeRef->toString(),
-                    $this->ncrCache->getNode($nodeRef)
-                );
+                $response->addToMap('nodes', $nodeRef->toString(), $this->ncrCache->getNode($nodeRef));
             } catch (\Throwable $e) {
-                $response->addToSet(GetNodeBatchResponseV1Mixin::MISSING_NODE_REFS_FIELD, [$nodeRef]);
+                $response->addToSet('missing_node_refs', [$nodeRef]);
             }
         }
 
         unset($this->pickup[$requestId]);
     }
 
-    private function getSlugCacheKey(SchemaQName $qname, string $slug): string
+    protected function getSlugCacheKey(SchemaQName $qname, string $slug): string
     {
         return str_replace('-', '_', sprintf(
             'stnr.%s.%s.%s',
@@ -189,5 +177,10 @@ final class NcrRequestInterceptor implements EventSubscriber
             $qname->getMessage(),
             md5($slug)
         ));
+    }
+
+    protected function getSlugCacheTtl(SchemaQName $qname, Message $request): int
+    {
+        return 300;
     }
 }

--- a/src/NodeCommandBinder.php
+++ b/src/NodeCommandBinder.php
@@ -12,12 +12,6 @@ use Gdbots\Pbjx\DependencyInjection\PbjxBinder;
 use Gdbots\Pbjx\Event\PbjxEvent;
 use Gdbots\Pbjx\EventSubscriber;
 use Gdbots\Pbjx\Exception\RequestHandlingFailed;
-use Gdbots\Schemas\Ncr\Command\RenameNodeV1;
-use Gdbots\Schemas\Ncr\Command\UpdateNodeV1;
-use Gdbots\Schemas\Ncr\Mixin\Node\NodeV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\RenameNode\RenameNodeV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\Sluggable\SluggableV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\UpdateNode\UpdateNodeV1Mixin;
 use Gdbots\Schemas\Ncr\Request\GetNodeRequestV1;
 use Gdbots\Schemas\Pbjx\Enum\Code;
 
@@ -26,48 +20,48 @@ class NodeCommandBinder implements EventSubscriber, PbjxBinder
     public static function getSubscribedEvents()
     {
         return [
-            RenameNodeV1::SCHEMA_CURIE . '.bind'      => 'bindRenameNode',
-            UpdateNodeV1::SCHEMA_CURIE . '.bind'      => 'bindUpdateNode',
+            'gdbots:ncr:command:rename-node.bind' => 'bindRenameNode',
+            'gdbots:ncr:command:update-node.bind' => 'bindUpdateNode',
             // deprecated mixins, will be removed in 3.x
-            RenameNodeV1Mixin::SCHEMA_CURIE . '.bind' => 'bindRenameNode',
-            UpdateNodeV1Mixin::SCHEMA_CURIE . '.bind' => 'bindUpdateNode',
+            'gdbots:ncr:mixin:rename-node.bind'   => 'bindRenameNode',
+            'gdbots:ncr:mixin:update-node.bind'   => 'bindUpdateNode',
         ];
     }
 
     public function bindRenameNode(PbjxEvent $pbjxEvent): void
     {
         $command = $pbjxEvent->getMessage();
-        Assertion::true($command->has(RenameNodeV1::NEW_SLUG_FIELD), 'Field "new_slug" is required.', 'new_slug');
+        Assertion::true($command->has('new_slug'), 'Field "new_slug" is required.', 'new_slug');
 
         $node = $this->getNode($pbjxEvent);
         $command
-            ->set(RenameNodeV1::NODE_STATUS_FIELD, $node->get(NodeV1Mixin::STATUS_FIELD))
-            ->set(RenameNodeV1::OLD_SLUG_FIELD, $node->get(SluggableV1Mixin::SLUG_FIELD))
-            ->set(RenameNodeV1::EXPECTED_ETAG_FIELD, $node->get(NodeV1Mixin::ETAG_FIELD));
+            ->set('node_status', $node->get('status'))
+            ->set('old_slug', $node->get('slug'))
+            ->set('expected_etag', $node->get('etag'));
     }
 
     public function bindUpdateNode(PbjxEvent $pbjxEvent): void
     {
         $node = $this->getNode($pbjxEvent);
         $pbjxEvent->getMessage()
-            ->set(UpdateNodeV1::OLD_NODE_FIELD, $node)
-            ->set(UpdateNodeV1::EXPECTED_ETAG_FIELD, $node->get(NodeV1Mixin::ETAG_FIELD));
+            ->set('old_node', $node)
+            ->set('expected_etag', $node->get('etag'));
     }
 
     protected function getNode(PbjxEvent $pbjxEvent): Message
     {
         $command = $pbjxEvent->getMessage();
-        Assertion::true($command->has(UpdateNodeV1::NODE_REF_FIELD), 'Field "node_ref" is required.', 'node_ref');
+        Assertion::true($command->has('node_ref'), 'Field "node_ref" is required.', 'node_ref');
 
         /** @var NodeRef $nodeRef */
-        $nodeRef = $command->get(UpdateNodeV1::NODE_REF_FIELD);
+        $nodeRef = $command->get('node_ref');
         $pbjx = $pbjxEvent::getPbjx();
 
         try {
             $request = GetNodeRequestV1::create()
-                ->set(GetNodeRequestV1::CONSISTENT_READ_FIELD, true)
-                ->set(GetNodeRequestV1::NODE_REF_FIELD, $nodeRef)
-                ->set(GetNodeRequestV1::QNAME_FIELD, $nodeRef->getQName()->toString());
+                ->set('consistent_read', true)
+                ->set('node_ref', $nodeRef)
+                ->set('qname', $nodeRef->getQName()->toString());
 
             $response = $pbjx->copyContext($command, $request)->request($request);
         } catch (RequestHandlingFailed $e) {
@@ -80,14 +74,14 @@ class NodeCommandBinder implements EventSubscriber, PbjxBinder
             throw $e;
         }
 
-        $expectedEtag = $command->get(UpdateNodeV1::EXPECTED_ETAG_FIELD);
-        $actualEtag = $response->get($response::NODE_FIELD)->get(NodeV1Mixin::ETAG_FIELD);
+        $expectedEtag = $command->get('expected_etag');
+        $actualEtag = $response->get('node')->get('etag');
         if (null !== $expectedEtag && $expectedEtag !== $actualEtag) {
             throw new OptimisticCheckFailed(
                 sprintf('NodeRef [%s] did not have expected etag [%s].', $nodeRef, $expectedEtag)
             );
         }
 
-        return $response->get($response::NODE_FIELD)->freeze();
+        return $response->get('node')->freeze();
     }
 }

--- a/src/PublishNodeHandler.php
+++ b/src/PublishNodeHandler.php
@@ -8,8 +8,6 @@ use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Command\PublishNodeV1;
-use Gdbots\Schemas\Ncr\Mixin\PublishNode\PublishNodeV1Mixin;
 
 class PublishNodeHandler implements CommandHandler
 {
@@ -27,8 +25,8 @@ class PublishNodeHandler implements CommandHandler
     public static function handlesCuries(): array
     {
         // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin(PublishNodeV1Mixin::SCHEMA_CURIE_MAJOR, false);
-        $curies[] = PublishNodeV1::SCHEMA_CURIE;
+        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:publish-node:v1', false);
+        $curies[] = 'gdbots:ncr:command:publish-node';
         return $curies;
     }
 
@@ -41,7 +39,7 @@ class PublishNodeHandler implements CommandHandler
     public function handleCommand(Message $command, Pbjx $pbjx): void
     {
         /** @var NodeRef $nodeRef */
-        $nodeRef = $command->get(PublishNodeV1::NODE_REF_FIELD);
+        $nodeRef = $command->get('node_ref');
         $context = ['causator' => $command];
 
         $node = $this->ncr->getNode($nodeRef, true, $context);

--- a/src/PublishableWatcher.php
+++ b/src/PublishableWatcher.php
@@ -7,21 +7,19 @@ use Gdbots\Ncr\Event\NodeProjectedEvent;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\EventSubscriber;
 use Gdbots\Schemas\Ncr\Command\PublishNodeV1;
-use Gdbots\Schemas\Ncr\Event\NodeScheduledV1;
-use Gdbots\Schemas\Ncr\Mixin\Publishable\PublishableV1Mixin;
 
 class PublishableWatcher implements EventSubscriber
 {
     public static function getSubscribedEvents()
     {
         return [
-            PublishableV1Mixin::SCHEMA_CURIE . '.deleted'           => 'cancel',
-            PublishableV1Mixin::SCHEMA_CURIE . '.expired'           => 'cancel',
-            PublishableV1Mixin::SCHEMA_CURIE . '.marked-as-draft'   => 'cancel',
-            PublishableV1Mixin::SCHEMA_CURIE . '.marked-as-pending' => 'cancel',
-            PublishableV1Mixin::SCHEMA_CURIE . '.published'         => 'cancel',
-            PublishableV1Mixin::SCHEMA_CURIE . '.scheduled'         => 'schedule',
-            PublishableV1Mixin::SCHEMA_CURIE . '.unpublished'       => 'cancel',
+            'gdbots:ncr:mixin:publishable.deleted'           => 'cancel',
+            'gdbots:ncr:mixin:publishable.expired'           => 'cancel',
+            'gdbots:ncr:mixin:publishable.marked-as-draft'   => 'cancel',
+            'gdbots:ncr:mixin:publishable.marked-as-pending' => 'cancel',
+            'gdbots:ncr:mixin:publishable.published'         => 'cancel',
+            'gdbots:ncr:mixin:publishable.scheduled'         => 'schedule',
+            'gdbots:ncr:mixin:publishable.unpublished'       => 'cancel',
         ];
     }
 
@@ -47,13 +45,13 @@ class PublishableWatcher implements EventSubscriber
         $node = $pbjxEvent->getNode();
 
         /** @var NodeRef $nodeRef */
-        $nodeRef = $event->get(NodeScheduledV1::NODE_REF_FIELD) ?: $node->generateNodeRef();
+        $nodeRef = $event->get('node_ref') ?: $node->generateNodeRef();
         /** @var \DateTimeInterface $publishAt */
-        $publishAt = $event->get(NodeScheduledV1::PUBLISH_AT_FIELD);
+        $publishAt = $event->get('publish_at');
 
         $command = PublishNodeV1::create()
-            ->set(PublishNodeV1::NODE_REF_FIELD, $nodeRef)
-            ->set(PublishNodeV1::PUBLISH_AT_FIELD, $publishAt);
+            ->set('node_ref', $nodeRef)
+            ->set('publish_at', $publishAt);
 
         $timestamp = $publishAt->getTimestamp();
         if ($timestamp <= time()) {

--- a/src/Repository/DynamoDb/NodeTable.php
+++ b/src/Repository/DynamoDb/NodeTable.php
@@ -9,7 +9,6 @@ use Gdbots\Ncr\Exception\RepositoryOperationFailed;
 use Gdbots\Pbj\Message;
 use Gdbots\Pbj\Util\ClassUtil;
 use Gdbots\Pbjx\Util\ShardUtil;
-use Gdbots\Schemas\Ncr\Mixin\Node\NodeV1Mixin;
 use Gdbots\Schemas\Pbjx\Enum\Code;
 
 /**
@@ -215,7 +214,7 @@ class NodeTable
     protected function addShardAttributes(array &$item, Message $node): void
     {
         foreach ([16, 32, 64, 128, 256] as $shard) {
-            $item["__s{$shard}"] = ['N' => (string)ShardUtil::determineShard($item[NodeV1Mixin::_ID_FIELD]['S'], $shard)];
+            $item["__s{$shard}"] = ['N' => (string)ShardUtil::determineShard($item['_id']['S'], $shard)];
         }
     }
 

--- a/src/Search/Elastica/IndexManager.php
+++ b/src/Search/Elastica/IndexManager.php
@@ -11,7 +11,6 @@ use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\SchemaQName;
 use Gdbots\Pbj\Util\ClassUtil;
 use Gdbots\Pbj\Util\NumberUtil;
-use Gdbots\Schemas\Ncr\Mixin\Node\NodeV1Mixin;
 use Gdbots\Schemas\Pbjx\Enum\Code;
 
 class IndexManager
@@ -256,13 +255,13 @@ class IndexManager
     protected function createMapping(): Mapping
     {
         $builder = $this->getMappingBuilder();
-        foreach (MessageResolver::findAllUsingMixin(NodeV1Mixin::SCHEMA_CURIE_MAJOR) as $curie) {
+        foreach (MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:node:v1') as $curie) {
             $builder->addSchema(MessageResolver::resolveCurie($curie)::schema());
         }
 
         $mapping = $builder->build();
         $properties = $mapping->getProperties();
-        unset($properties[NodeV1Mixin::_ID_FIELD]);
+        unset($properties['_id']);
         $properties[self::CREATED_AT_ISO_FIELD_NAME] = MappingBuilder::TYPES['date'];
         $mapping->setProperties($properties);
 

--- a/src/Search/Elastica/MappingBuilder.php
+++ b/src/Search/Elastica/MappingBuilder.php
@@ -6,13 +6,12 @@ namespace Gdbots\Ncr\Search\Elastica;
 use Gdbots\Pbj\Field;
 use Gdbots\Pbj\Marshaler\Elastica\MappingBuilder as BaseMappingBuilder;
 use Gdbots\Pbj\Schema;
-use Gdbots\Schemas\Ncr\Mixin\Node\NodeV1Mixin;
 
 class MappingBuilder extends BaseMappingBuilder
 {
     protected function filterProperties(Schema $schema, Field $field, string $path, array $properties): array
     {
-        if ($path === NodeV1Mixin::TITLE_FIELD) {
+        if ($path === 'title') {
             $properties['fields'] = [
                 'completion' => ['type' => 'completion', 'analyzer' => 'pbj_keyword'],
                 'raw'        => ['type' => 'keyword', 'normalizer' => 'pbj_keyword'],

--- a/src/Search/Elastica/NodeMapper.php
+++ b/src/Search/Elastica/NodeMapper.php
@@ -6,7 +6,6 @@ namespace Gdbots\Ncr\Search\Elastica;
 use Elastica\Document;
 use Gdbots\Pbj\Message;
 use Gdbots\Pbj\Util\DateUtil;
-use Gdbots\Schemas\Ncr\Mixin\Node\NodeV1Mixin;
 
 class NodeMapper
 {
@@ -22,7 +21,7 @@ class NodeMapper
     {
         $document->set(
             IndexManager::CREATED_AT_ISO_FIELD_NAME,
-            $node->get(NodeV1Mixin::CREATED_AT_FIELD)->toDateTime()->format(DateUtil::ISO8601_ZULU)
+            $node->get('created_at')->toDateTime()->format(DateUtil::ISO8601_ZULU)
         );
     }
 }

--- a/src/Search/Elastica/QueryFactory.php
+++ b/src/Search/Elastica/QueryFactory.php
@@ -16,9 +16,6 @@ use Gdbots\QueryParser\Node\Field;
 use Gdbots\QueryParser\Node\Numbr;
 use Gdbots\QueryParser\Node\Word;
 use Gdbots\QueryParser\ParsedQuery;
-use Gdbots\Schemas\Ncr\Mixin\Node\NodeV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\Publishable\PublishableV1Mixin;
-use Gdbots\Schemas\Ncr\Mixin\SearchNodesRequest\SearchNodesRequestV1Mixin;
 
 class QueryFactory
 {
@@ -63,23 +60,23 @@ class QueryFactory
 
         $dateFilters = [
             [
-                'query'    => SearchNodesRequestV1Mixin::CREATED_AFTER_FIELD,
-                'field'    => NodeV1Mixin::CREATED_AT_FIELD,
+                'query'    => 'created_after',
+                'field'    => 'created_at',
                 'operator' => ComparisonOperator::GT(),
             ],
             [
-                'query'    => SearchNodesRequestV1Mixin::CREATED_BEFORE_FIELD,
-                'field'    => NodeV1Mixin::CREATED_AT_FIELD,
+                'query'    => 'created_before',
+                'field'    => 'created_at',
                 'operator' => ComparisonOperator::LT(),
             ],
             [
-                'query'    => SearchNodesRequestV1Mixin::UPDATED_AFTER_FIELD,
-                'field'    => NodeV1Mixin::UPDATED_AT_FIELD,
+                'query'    => 'updated_after',
+                'field'    => 'updated_at',
                 'operator' => ComparisonOperator::GT(),
             ],
             [
-                'query'    => SearchNodesRequestV1Mixin::UPDATED_BEFORE_FIELD,
-                'field'    => NodeV1Mixin::UPDATED_AT_FIELD,
+                'query'    => 'updated_before',
+                'field'    => 'updated_at',
                 'operator' => ComparisonOperator::LT(),
             ],
         ];
@@ -102,14 +99,14 @@ class QueryFactory
 
     protected function applyStatus(Message $request, ParsedQuery $parsedQuery): void
     {
-        if (!$request->has(SearchNodesRequestV1Mixin::STATUS_FIELD)) {
+        if (!$request->has('status')) {
             return;
         }
 
         $required = BoolOperator::REQUIRED();
         $parsedQuery->addNode(new Field(
-            NodeV1Mixin::STATUS_FIELD,
-            new Word((string)$request->get(SearchNodesRequestV1Mixin::STATUS_FIELD), $required),
+            'status',
+            new Word((string)$request->get('status'), $required),
             $required
         ));
     }
@@ -128,13 +125,13 @@ class QueryFactory
     {
         $dateFilters = [
             [
-                'query'    => SearchNodesRequestV1Mixin::PUBLISHED_AFTER_FIELD,
-                'field'    => PublishableV1Mixin::PUBLISHED_AT_FIELD,
+                'query'    => 'published_after',
+                'field'    => 'published_at',
                 'operator' => ComparisonOperator::GT,
             ],
             [
-                'query'    => SearchNodesRequestV1Mixin::PUBLISHED_BEFORE_FIELD,
-                'field'    => PublishableV1Mixin::PUBLISHED_AT_FIELD,
+                'query'    => 'published_before',
+                'field'    => 'published_at',
                 'operator' => ComparisonOperator::LT,
             ],
         ];
@@ -177,11 +174,11 @@ class QueryFactory
      */
     protected function filterStatuses(Message $request, Query\BoolQuery $query): void
     {
-        if (!$request->has(SearchNodesRequestV1Mixin::STATUSES_FIELD)) {
+        if (!$request->has('statuses')) {
             return;
         }
 
-        $statuses = array_map('strval', $request->get(SearchNodesRequestV1Mixin::STATUSES_FIELD));
-        $query->addFilter(new Query\Terms(NodeV1Mixin::STATUS_FIELD, $statuses));
+        $statuses = array_map('strval', $request->get('statuses'));
+        $query->addFilter(new Query\Terms('status', $statuses));
     }
 }

--- a/src/UnlockNodeHandler.php
+++ b/src/UnlockNodeHandler.php
@@ -8,8 +8,6 @@ use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Command\UnlockNodeV1;
-use Gdbots\Schemas\Ncr\Mixin\UnlockNode\UnlockNodeV1Mixin;
 
 class UnlockNodeHandler implements CommandHandler
 {
@@ -18,8 +16,8 @@ class UnlockNodeHandler implements CommandHandler
     public static function handlesCuries(): array
     {
         // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin(UnlockNodeV1Mixin::SCHEMA_CURIE_MAJOR, false);
-        $curies[] = UnlockNodeV1::SCHEMA_CURIE;
+        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:unlock-node:v1', false);
+        $curies[] = 'gdbots:ncr:command:unlock-node';
         return $curies;
     }
 
@@ -31,7 +29,7 @@ class UnlockNodeHandler implements CommandHandler
     public function handleCommand(Message $command, Pbjx $pbjx): void
     {
         /** @var NodeRef $nodeRef */
-        $nodeRef = $command->get(UnlockNodeV1::NODE_REF_FIELD);
+        $nodeRef = $command->get('node_ref');
         $context = ['causator' => $command];
 
         $node = $this->ncr->getNode($nodeRef, true, $context);

--- a/src/UnpublishNodeHandler.php
+++ b/src/UnpublishNodeHandler.php
@@ -8,8 +8,6 @@ use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Command\UnpublishNodeV1;
-use Gdbots\Schemas\Ncr\Mixin\UnpublishNode\UnpublishNodeV1Mixin;
 
 class UnpublishNodeHandler implements CommandHandler
 {
@@ -18,8 +16,8 @@ class UnpublishNodeHandler implements CommandHandler
     public static function handlesCuries(): array
     {
         // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin(UnpublishNodeV1Mixin::SCHEMA_CURIE_MAJOR, false);
-        $curies[] = UnpublishNodeV1::SCHEMA_CURIE;
+        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:unpublish-node:v1', false);
+        $curies[] = 'gdbots:ncr:command:unpublish-node';
         return $curies;
     }
 
@@ -31,7 +29,7 @@ class UnpublishNodeHandler implements CommandHandler
     public function handleCommand(Message $command, Pbjx $pbjx): void
     {
         /** @var NodeRef $nodeRef */
-        $nodeRef = $command->get(UnpublishNodeV1::NODE_REF_FIELD);
+        $nodeRef = $command->get('node_ref');
         $context = ['causator' => $command];
 
         $node = $this->ncr->getNode($nodeRef, true, $context);

--- a/src/UpdateNodeHandler.php
+++ b/src/UpdateNodeHandler.php
@@ -8,25 +8,23 @@ use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
-use Gdbots\Schemas\Ncr\Command\UpdateNodeV1;
-use Gdbots\Schemas\Ncr\Mixin\UpdateNode\UpdateNodeV1Mixin;
 
 class UpdateNodeHandler implements CommandHandler
 {
     public static function handlesCuries(): array
     {
         // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin(UpdateNodeV1Mixin::SCHEMA_CURIE_MAJOR, false);
-        $curies[] = UpdateNodeV1::SCHEMA_CURIE;
+        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:update-node:v1', false);
+        $curies[] = 'gdbots:ncr:command:update-node';
         return $curies;
     }
 
     public function handleCommand(Message $command, Pbjx $pbjx): void
     {
         /** @var NodeRef $nodeRef */
-        $nodeRef = $command->get(UpdateNodeV1::NODE_REF_FIELD);
+        $nodeRef = $command->get('node_ref');
         /** @var Message $node */
-        $node = $command->get(UpdateNodeV1::OLD_NODE_FIELD);
+        $node = $command->get('old_node');
         $context = ['causator' => $command];
 
         $aggregate = AggregateResolver::resolve($nodeRef->getQName())::fromNode($node, $pbjx);

--- a/src/UpdateNodeLabelsHandler.php
+++ b/src/UpdateNodeLabelsHandler.php
@@ -4,21 +4,19 @@ declare(strict_types=1);
 namespace Gdbots\Ncr;
 
 use Gdbots\Pbj\Message;
-use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
 
-class RenameNodeHandler implements CommandHandler
+class UpdateNodeLabelsHandler implements CommandHandler
 {
     protected Ncr $ncr;
 
     public static function handlesCuries(): array
     {
-        // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:rename-node:v1', false);
-        $curies[] = 'gdbots:ncr:command:rename-node';
-        return $curies;
+        return [
+            'gdbots:ncr:command:update-node-labels',
+        ];
     }
 
     public function __construct(Ncr $ncr)
@@ -35,7 +33,7 @@ class RenameNodeHandler implements CommandHandler
         $node = $this->ncr->getNode($nodeRef, true, $context);
         $aggregate = AggregateResolver::resolve($nodeRef->getQName())::fromNode($node, $pbjx);
         $aggregate->sync($context);
-        $aggregate->renameNode($command);
+        $aggregate->updateNodeLabels($command);
         $aggregate->commit($context);
     }
 }

--- a/src/UpdateNodeTagsHandler.php
+++ b/src/UpdateNodeTagsHandler.php
@@ -4,21 +4,19 @@ declare(strict_types=1);
 namespace Gdbots\Ncr;
 
 use Gdbots\Pbj\Message;
-use Gdbots\Pbj\MessageResolver;
 use Gdbots\Pbj\WellKnown\NodeRef;
 use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\Pbjx;
 
-class RenameNodeHandler implements CommandHandler
+class UpdateNodeTagsHandler implements CommandHandler
 {
     protected Ncr $ncr;
 
     public static function handlesCuries(): array
     {
-        // deprecated mixins, will be removed in 3.x
-        $curies = MessageResolver::findAllUsingMixin('gdbots:ncr:mixin:rename-node:v1', false);
-        $curies[] = 'gdbots:ncr:command:rename-node';
-        return $curies;
+        return [
+            'gdbots:ncr:command:update-node-tags',
+        ];
     }
 
     public function __construct(Ncr $ncr)
@@ -35,7 +33,7 @@ class RenameNodeHandler implements CommandHandler
         $node = $this->ncr->getNode($nodeRef, true, $context);
         $aggregate = AggregateResolver::resolve($nodeRef->getQName())::fromNode($node, $pbjx);
         $aggregate->sync($context);
-        $aggregate->renameNode($command);
+        $aggregate->updateNodeTags($command);
         $aggregate->commit($context);
     }
 }

--- a/tests/Repository/InMemoryNcrTest.php
+++ b/tests/Repository/InMemoryNcrTest.php
@@ -59,20 +59,20 @@ class InMemoryNcrTest extends TestCase
     public function testPutNodeWithValidExpectedEtag(): void
     {
         $expectedEtag = 'test';
-        $expectedNode = UserV1::create()->set(UserV1::ETAG_FIELD, $expectedEtag);
+        $expectedNode = UserV1::create()->set('etag', $expectedEtag);
         $this->ncr->putNode($expectedNode);
         $nodeRef = NodeRef::fromNode($expectedNode);
 
         $nextNode = $this->ncr->getNode($nodeRef);
         $this->ncr->putNode($nextNode, $expectedEtag);
-        $this->assertSame($expectedNode->get(UserV1::ETAG_FIELD), $nextNode->get(UserV1::ETAG_FIELD));
+        $this->assertSame($expectedNode->get('etag'), $nextNode->get('etag'));
     }
 
     public function testPutNodeWithInvalidExpectedEtag1()
     {
         $this->expectException(OptimisticCheckFailed::class);
         $expectedEtag = 'test';
-        $expectedNode = UserV1::create()->set(UserV1::ETAG_FIELD, $expectedEtag);
+        $expectedNode = UserV1::create()->set('etag', $expectedEtag);
         $this->ncr->putNode($expectedNode);
         $nodeRef = NodeRef::fromNode($expectedNode);
 
@@ -85,7 +85,7 @@ class InMemoryNcrTest extends TestCase
     {
         $this->expectException(OptimisticCheckFailed::class);
         $expectedEtag = 'test';
-        $expectedNode = UserV1::create()->set(UserV1::ETAG_FIELD, $expectedEtag);
+        $expectedNode = UserV1::create()->set('etag', $expectedEtag);
         $this->ncr->putNode($expectedNode);
         $nodeRef = NodeRef::fromNode($expectedNode);
 


### PR DESCRIPTION
* Add implementations for `gdbots:ncr:command:update-node-labels` and `gdbots:ncr:command:update-node-tags`.
* Fix bug in `GetNodeRequestHandler` where `$nodeRef` wasn't set when doing a slug lookup.
* Remove use of mixin/message constants for fields and schema refs as it's too noisy and isn't enough of a help to warrant it.