### PR TITLE
v3.1.2

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -2,6 +2,10 @@
 This changelog references the relevant changes done in 3.x versions.
 
 
+## v3.1.2
+* In `GetNodeRequestHandler::handleRequest` do not treat aggregate-synced nodes with empty event streams as valid.
+
+
 ## v3.1.1
 * Update `DynamoDbNcr::doPipeNodes` to allow iteration key in piping nodes to be string or int.
 

--- a/src/GetNodeRequestHandler.php
+++ b/src/GetNodeRequestHandler.php
@@ -46,7 +46,12 @@ class GetNodeRequestHandler implements RequestHandler
 
                 $aggregate = AggregateResolver::resolve($nodeRef->getQName())::fromNodeRef($nodeRef, $pbjx);
                 $aggregate->sync($context);
-                return $response->set('node', $aggregate->getNode());
+                $node = $aggregate->getNode();
+                if (!$node->has('last_event_ref')) {
+                    // created from empty stream
+                    throw $nf;
+                }
+                return $response->set('node', $node);
             } catch (\Throwable $e) {
                 throw $e;
             }


### PR DESCRIPTION
* In `GetNodeRequestHandler::handleRequest` do not treat aggregate-synced nodes with empty event streams as valid.